### PR TITLE
refactor of the node resource update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Lists the changes in the provider.
 
 - refactor the node resource update logic, allow change of more properties when
   node hasn't been started yet
+- fix node tag handling (also a regression in cmlclient)
 - for image definition data source: change the attribute name of the node
   definition filter from `node_definition_id` to `nodedefinition` for consistency
 - improve test coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Lists the changes in the provider.
 
+## Version 0.5.1
+
+- refactor the node resource update logic, allow change of more properties when
+  node hasn't been started yet
+- for image definition data source: change the attribute name of the node
+  definition filter from `node_definition_id` to `nodedefinition` for consistency
+- improve test coverage
+- documentation improvements
+- dependency updates
+
+## Version 0.5.0
+
+- refactor to work with Terraform Plugin Framework 1.0.1
+- added an image definition data source
+- removed the GH secret tool from the repo
+- dependency updates
+
+## Version 0.4.2
+
+- fixed node properties (compute ID and VNC key)
+- added the combine workflow action (internal)
+- bumped gocmlclient to 0.0.6
+- dependency updates
+
 ## Version 0.4.1
 
 - documentation consistency and small fixes

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,10 @@
 # TODO
 
-As this provider is "work-in-progress", there's still plenty of work to do:
+As this provider is "work-in-progress", there's still plenty of work to do.
 
-- documentation (content, consistency)
-- tests (only a few so far)
-- "filter" implementation for lab details data source (if needed at all)
-- naming consistency (cml vs cml2)?
 - additional resources and data sources
+- improved documentation and examples
+- better test coverage(unit/acceptance)
 
 Especially the last bullet requires some discussion in terms of what makes
 sense and what doesn't.
@@ -21,13 +19,20 @@ There's some documentation around design
 but that wasn't really conclusive; it also seemed to be referencing outdated
 material.
 
-## Modularization
-
-Need to likely move the actual golang CML client library to its own repo.
-
 ## Items Done
 
+- basic acceptance tests
+- documentation (content, consistency)
+- added image definition data source
 - add CA pem file to provider config
+- move the actual golang CML client library to its own repo
+- naming consistency (cml vs cml2) -- should be OK by now
+- image schema unit test
+- fix documentation of data sources ("optional schema props")
+
+## Not doing
+
+- "filter" implementation for lab details data source (if needed at all)
 
 ## References
 

--- a/docs/data-sources/images.md
+++ b/docs/data-sources/images.md
@@ -3,19 +3,19 @@
 page_title: "cml2_images Data Source - terraform-provider-cml2"
 subcategory: ""
 description: |-
-  A data source that retrieves image definitions from the controller. The optional node_definition ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned.
+  A data source that retrieves image definitions from the controller. The optional nodedefinition ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned.
 ---
 
 # cml2_images (Data Source)
 
-A data source that retrieves image definitions from the controller. The optional `node_definition` ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned.
+A data source that retrieves image definitions from the controller. The optional `nodedefinition` ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned.
 
 ## Example Usage
 
 ```terraform
 data "cml2_images" "test" {
   # filter images for the Alpine node definition
-  node_definition = "alpine"
+  nodedefinition = "alpine"
 }
 
 locals {
@@ -40,19 +40,15 @@ output "newest_alpine" {
 
 ### Optional
 
-- `node_definition` (String) A node definition ID to filter the image list.
+- `nodedefinition` (String) A node definition ID to filter the image list.
 
 ### Read-Only
 
-- `id` (String) A UUID. The attribute required by the framework.
-- `image_list` (Attributes List) A list of all image definitions available on the controller, potentially filtered by the provided `node_definition` attribute. (see [below for nested schema](#nestedatt--image_list))
+- `id` (String) A UUID. The presence of the ID attribute is mandated by the framework. The attribute is a random UUID and has no actual significance.
+- `image_list` (Attributes List) A list of all image definitions available on the controller, potentially filtered by the provided `nodedefinition` attribute. (see [below for nested schema](#nestedatt--image_list))
 
 <a id="nestedatt--image_list"></a>
 ### Nested Schema for `image_list`
-
-Optional:
-
-- `node_definition_id` (String) ID of the node definition this image belongs to
 
 Read-Only:
 
@@ -63,6 +59,7 @@ Read-Only:
 - `description` (String) Description of this image definition
 - `id` (String) ID to identifying the image
 - `label` (String) Text label of this image definition
+- `nodedefinition` (String) ID of the node definition this image belongs to
 - `ram` (Number) Image specific RAM value, can be null
 - `read_only` (Boolean) Is this image definition read only?
 - `schema_version` (String) Version of the image definition schemage

--- a/docs/data-sources/lab.md
+++ b/docs/data-sources/lab.md
@@ -3,12 +3,12 @@
 page_title: "cml2_lab Data Source - terraform-provider-cml2"
 subcategory: ""
 description: |-
-  A lab data source. Either the lab id or the lab title must be provided to retrieve the lab data from the controller.  Note that all of the attributes of the lab element are read-only even though the auto-generated schema documentation lists some of them as "optional".
+  A lab data source. Either the lab id or the lab title must be provided to retrieve the lab data from the controller.
 ---
 
 # cml2_lab (Data Source)
 
-A lab data source. Either the lab `id` or the lab `title` must be provided to retrieve the `lab` data from the controller.  Note that **all** of the attributes of the lab element are read-only even though the auto-generated schema documentation lists some of them as "optional".
+A lab data source. Either the lab `id` or the lab `title` must be provided to retrieve the `lab` data from the controller.
 
 ## Example Usage
 
@@ -44,22 +44,19 @@ output "result" {
 <a id="nestedatt--lab"></a>
 ### Nested Schema for `lab`
 
-Optional:
-
-- `description` (String) Lab description.
-- `groups` (Attributes List) Groups assigned to the lab. (see [below for nested schema](#nestedatt--lab--groups))
-- `notes` (String) Lab notes.
-- `title` (String) Title of the lab.
-
 Read-Only:
 
 - `created` (String) Creation date/time string in ISO8601 format.
+- `description` (String) Lab description.
+- `groups` (Attributes List) Groups assigned to the lab. (see [below for nested schema](#nestedatt--lab--groups))
 - `id` (String) Lab identifier, a UUID.
 - `link_count` (Number) Number of links in the lab.
 - `modified` (String) Modification date/time string in ISO8601 format.
 - `node_count` (Number) Number of nodes in the lab.
+- `notes` (String) Lab notes.
 - `owner` (String) Owner of the lab, a UUID4.
 - `state` (String) Lab state, one of `DEFINED_ON_CORE`, `STARTED` or `STOPPED`.
+- `title` (String) Title of the lab.
 
 <a id="nestedatt--lab--groups"></a>
 ### Nested Schema for `lab.groups`

--- a/docs/data-sources/node.md
+++ b/docs/data-sources/node.md
@@ -3,12 +3,12 @@
 page_title: "cml2_node Data Source - terraform-provider-cml2"
 subcategory: ""
 description: |-
-  A node data source.  Both, the node id and the lab_id must be provided to retrieve the node data from the controller.  Note that all of the attributes of the node element are read-only even though the auto-generated schema documentation lists some of them as "optional".
+  A node data source.  Both, the node id and the lab_id must be provided to retrieve the node data from the controller.
 ---
 
 # cml2_node (Data Source)
 
-A node data source.  Both, the node `id` and the `lab_id` must be provided to retrieve the `node` data from the controller.  Note that **all** of the attributes of the node element are read-only even though the auto-generated schema documentation lists some of them as "optional".
+A node data source.  Both, the node `id` and the `lab_id` must be provided to retrieve the `node` data from the controller.
 
 ## Example Usage
 
@@ -40,30 +40,27 @@ output "result" {
 <a id="nestedatt--node"></a>
 ### Nested Schema for `node`
 
-Optional:
-
-- `boot_disk_size` (Number) Size of boot disk volume, in GB.
-- `configuration` (String) Node configuration.
-- `cpu_limit` (Number) CPU limit in %, 20-100.
-- `cpus` (Number) Number of CPUs.
-- `data_volume` (Number) Size of data volume, in GB.
-- `imagedefinition` (String) Image definition, must match the node type.
-- `ram` (Number) Amount of RAM, megabytes.
-- `tags` (List of String) List of tags of the node.
-- `x` (Number) X coordinate on the topology canvas.
-- `y` (Number) Y coordinate on the topology canvas.
-
 Read-Only:
 
+- `boot_disk_size` (Number) Size of boot disk volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
 - `compute_id` (String) ID of a compute this node is on, a UUID4.
+- `configuration` (String) Node configuration. Can be changed until the node is started once. Will require a replace in that case.
+- `cpu_limit` (Number) CPU limit in %, 20-100. Can be changed until the node is started once. Will require a replace in that case.
+- `cpus` (Number) Number of CPUs. Can be changed until the node is started once. Will require a replace in that case.
+- `data_volume` (Number) Size of data volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
 - `id` (String) Node ID (UUID).
+- `imagedefinition` (String) Image definition, must match the node type. Can be changed until the node is started once. Will require a replace in that case.
 - `interfaces` (Attributes List) List of interfaces on the node. (see [below for nested schema](#nestedatt--node--interfaces))
 - `lab_id` (String) Lab ID containing the node (UUID).
 - `label` (String) Node label.
-- `nodedefinition` (String) Node definition / type.
+- `nodedefinition` (String) Node definition / type. This can only be set at create time.
+- `ram` (Number) Amount of RAM, megabytes. Can be changed until the node is started once. Will require a replace in that case.
 - `serial_devices` (List of Object) List of serial devices (consoles). (see [below for nested schema](#nestedatt--node--serial_devices))
 - `state` (String) Node state (`DEFINED_ON_CORE`, `STOPPED`, `STARTED`, `BOOTED`).
+- `tags` (List of String) List of tags of the node.
 - `vnc_key` (String) VNC key of console, a UUID4.
+- `x` (Number) X coordinate on the topology canvas.
+- `y` (Number) Y coordinate on the topology canvas.
 
 <a id="nestedatt--node--interfaces"></a>
 ### Nested Schema for `node.interfaces`

--- a/docs/resources/lifecycle.md
+++ b/docs/resources/lifecycle.md
@@ -189,17 +189,17 @@ Required:
 
 - `lab_id` (String) Lab ID containing the node (UUID).
 - `label` (String) Node label.
-- `nodedefinition` (String) Node definition / type.
+- `nodedefinition` (String) Node definition / type. This can only be set at create time.
 
 Optional:
 
-- `boot_disk_size` (Number) Size of boot disk volume, in GB.
-- `configuration` (String) Node configuration.
-- `cpu_limit` (Number) CPU limit in %, 20-100.
-- `cpus` (Number) Number of CPUs.
-- `data_volume` (Number) Size of data volume, in GB.
-- `imagedefinition` (String) Image definition, must match the node type.
-- `ram` (Number) Amount of RAM, megabytes.
+- `boot_disk_size` (Number) Size of boot disk volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
+- `configuration` (String) Node configuration. Can be changed until the node is started once. Will require a replace in that case.
+- `cpu_limit` (Number) CPU limit in %, 20-100. Can be changed until the node is started once. Will require a replace in that case.
+- `cpus` (Number) Number of CPUs. Can be changed until the node is started once. Will require a replace in that case.
+- `data_volume` (Number) Size of data volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
+- `imagedefinition` (String) Image definition, must match the node type. Can be changed until the node is started once. Will require a replace in that case.
+- `ram` (Number) Amount of RAM, megabytes. Can be changed until the node is started once. Will require a replace in that case.
 - `tags` (List of String) List of tags of the node.
 - `x` (Number) X coordinate on the topology canvas.
 - `y` (Number) Y coordinate on the topology canvas.

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -19,17 +19,17 @@ A node resource represents a CML node. At create time, the lab ID, a node defini
 
 - `lab_id` (String) Lab ID containing the node (UUID).
 - `label` (String) Node label.
-- `nodedefinition` (String) Node definition / type.
+- `nodedefinition` (String) Node definition / type. This can only be set at create time.
 
 ### Optional
 
-- `boot_disk_size` (Number) Size of boot disk volume, in GB.
-- `configuration` (String) Node configuration.
-- `cpu_limit` (Number) CPU limit in %, 20-100.
-- `cpus` (Number) Number of CPUs.
-- `data_volume` (Number) Size of data volume, in GB.
-- `imagedefinition` (String) Image definition, must match the node type.
-- `ram` (Number) Amount of RAM, megabytes.
+- `boot_disk_size` (Number) Size of boot disk volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
+- `configuration` (String) Node configuration. Can be changed until the node is started once. Will require a replace in that case.
+- `cpu_limit` (Number) CPU limit in %, 20-100. Can be changed until the node is started once. Will require a replace in that case.
+- `cpus` (Number) Number of CPUs. Can be changed until the node is started once. Will require a replace in that case.
+- `data_volume` (Number) Size of data volume, in GB. Can be changed until the node is started once. Will require a replace in that case.
+- `imagedefinition` (String) Image definition, must match the node type. Can be changed until the node is started once. Will require a replace in that case.
+- `ram` (Number) Amount of RAM, megabytes. Can be changed until the node is started once. Will require a replace in that case.
 - `tags` (List of String) List of tags of the node.
 - `x` (Number) X coordinate on the topology canvas.
 - `y` (Number) Y coordinate on the topology canvas.

--- a/examples/data-sources/cml2_images/data-source.tf
+++ b/examples/data-sources/cml2_images/data-source.tf
@@ -1,6 +1,6 @@
 data "cml2_images" "test" {
   # filter images for the Alpine node definition
-  node_definition = "alpine"
+  nodedefinition = "alpine"
 }
 
 locals {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.2
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/rschmied/gocmlclient v0.0.11
+	github.com/rschmied/gocmlclient v0.0.12
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.2
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/rschmied/gocmlclient v0.0.10
+	github.com/rschmied/gocmlclient v0.0.11
 	github.com/stretchr/testify v1.8.1
 )
 
@@ -45,7 +45,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/cli v1.1.4 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
@@ -68,7 +68,7 @@ require (
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
+	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,9 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mitchellh/cli v1.1.4 h1:qj8czE26AU4PbiaPXK5uVmMSM+V5BYsFBiM9HhGRLUA=
 github.com/mitchellh/cli v1.1.4/go.mod h1:vTLESy5mRhKOs9KDp0/RATawxP1UqBmdrpVRMnpcvKQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -179,8 +180,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
-github.com/rschmied/gocmlclient v0.0.10 h1:VQl9qeVyuPRVupmaiQkQoUBuV2560ajLqq5zPk0lP3w=
-github.com/rschmied/gocmlclient v0.0.10/go.mod h1:rqIwDAKg8cIyjZUmexYdwxeaNU9tmLNkbcrxpeaTRkQ=
+github.com/rschmied/gocmlclient v0.0.11 h1:2YggbbJYK8mVnUUmEPtd7KXMaHRx5sbQG+aAmTHyf0o=
+github.com/rschmied/gocmlclient v0.0.11/go.mod h1:rqIwDAKg8cIyjZUmexYdwxeaNU9tmLNkbcrxpeaTRkQ=
 github.com/rschmied/mockresponder v1.0.3 h1:HvYHzzVEzW4HmzFR5y3BiYTg2RTuFBKztFQCaYLX5dw=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
@@ -284,8 +285,8 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSgaFAGyInDXeWzUhvYH57G/5GKMn70=
-google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef h1:uQ2vjV/sHTsWSqdKeLqmwitzgvjMl7o4IdtHwUDXSJY=
+google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
-github.com/rschmied/gocmlclient v0.0.11 h1:2YggbbJYK8mVnUUmEPtd7KXMaHRx5sbQG+aAmTHyf0o=
-github.com/rschmied/gocmlclient v0.0.11/go.mod h1:rqIwDAKg8cIyjZUmexYdwxeaNU9tmLNkbcrxpeaTRkQ=
+github.com/rschmied/gocmlclient v0.0.12 h1:M2qH202SYsUZlhLP2UVCtZGeH5Nqk2khto8C98w7JdQ=
+github.com/rschmied/gocmlclient v0.0.12/go.mod h1:rqIwDAKg8cIyjZUmexYdwxeaNU9tmLNkbcrxpeaTRkQ=
 github.com/rschmied/mockresponder v1.0.3 h1:HvYHzzVEzW4HmzFR5y3BiYTg2RTuFBKztFQCaYLX5dw=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/internal/cmlschema/convert.go
+++ b/internal/cmlschema/convert.go
@@ -12,9 +12,14 @@ func Converter(rSchema map[string]r_schema.Attribute) map[string]ds_schema.Attri
 	for name, fromAttr := range rSchema {
 
 		// required := fromAttr.IsRequired()
-		required := false // for datasources, the required attrs are on the outside
-		computed := fromAttr.IsComputed()
-		optional := fromAttr.IsOptional()
+		// computed := fromAttr.IsComputed()
+		// optional := fromAttr.IsOptional()
+
+		// for a datasource, all attributes are computed and the required attrs
+		// are on the container / outside.
+		required := false
+		computed := true
+		optional := false
 
 		if !(required && computed && optional) {
 			computed = true

--- a/internal/cmlschema/image_def.go
+++ b/internal/cmlschema/image_def.go
@@ -16,7 +16,7 @@ import (
 // the ones ommitted are irrelevant for TF operations (e.g. disk paths)
 type ImageDefinitionModel struct {
 	ID            types.String `tfsdk:"id"`
-	NodeDefID     types.String `tfsdk:"node_definition_id"`
+	NodeDefID     types.String `tfsdk:"nodedefinition"`
 	Description   types.String `tfsdk:"description"`
 	Label         types.String `tfsdk:"label"`
 	ReadOnly      types.Bool   `tfsdk:"read_only"`
@@ -29,17 +29,17 @@ type ImageDefinitionModel struct {
 }
 
 var ImageDefAttrType = map[string]attr.Type{
-	"id":                 types.StringType,
-	"node_definition_id": types.StringType,
-	"description":        types.StringType,
-	"label":              types.StringType,
-	"read_only":          types.BoolType,
-	"ram":                types.Int64Type,
-	"cpus":               types.Int64Type,
-	"cpu_limit":          types.Int64Type,
-	"data_volume":        types.Int64Type,
-	"boot_disk_size":     types.Int64Type,
-	"schema_version":     types.StringType,
+	"id":             types.StringType,
+	"nodedefinition": types.StringType,
+	"description":    types.StringType,
+	"label":          types.StringType,
+	"read_only":      types.BoolType,
+	"ram":            types.Int64Type,
+	"cpus":           types.Int64Type,
+	"cpu_limit":      types.Int64Type,
+	"data_volume":    types.Int64Type,
+	"boot_disk_size": types.Int64Type,
+	"schema_version": types.StringType,
 }
 
 // ImageDef returns the schema for the Image definition model
@@ -49,9 +49,9 @@ func ImageDef() map[string]schema.Attribute {
 			Description: "ID to identifying the image",
 			Computed:    true,
 		},
-		"node_definition_id": schema.StringAttribute{
+		"nodedefinition": schema.StringAttribute{
 			Description: "ID of the node definition this image belongs to",
-			Optional:    true,
+			Computed:    true,
 		},
 		"description": schema.StringAttribute{
 			Description: "Description of this image definition",

--- a/internal/cmlschema/image_def_test.go
+++ b/internal/cmlschema/image_def_test.go
@@ -1,0 +1,57 @@
+package cmlschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmlclient "github.com/rschmied/gocmlclient"
+	"github.com/rschmied/terraform-provider-cml2/internal/cmlschema"
+	"github.com/stretchr/testify/assert"
+)
+
+var image *cmlclient.ImageDefinition = &cmlclient.ImageDefinition{
+
+	ID:            "22e72ed9-238f-4f8f-966f-4a5dc6b8de1a",
+	SchemaVersion: "0.0.1",
+	NodeDefID:     "testnodedef",
+	Description:   "testdescription",
+	Label:         "Test Node Label",
+	DiskImage1:    "bla.qcpw2",
+	DiskImage2:    "",
+	DiskImage3:    "",
+	ReadOnly:      true,
+	DiskSubfolder: "bla",
+	RAM:           nil,
+	CPUs:          nil,
+	CPUlimit:      nil,
+	DataVolume:    nil,
+	BootDiskSize:  nil,
+}
+
+func TestImageDef(t *testing.T) {
+	diag := &diag.Diagnostics{}
+	ctx := context.Background()
+
+	value := cmlschema.NewImageDefinition(ctx, image, diag)
+	t.Logf("value: %+v", value)
+	t.Logf("errors: %+v", diag.Errors())
+	assert.False(t, diag.HasError())
+
+	var newImage cmlschema.ImageDefinitionModel
+	diag.Append(tfsdk.ValueAs(ctx, value, &newImage)...)
+	assert.False(t, diag.HasError())
+}
+
+func TestImageeSchema(t *testing.T) {
+	imageSchema := schema.Schema{
+		Attributes: cmlschema.ImageDef(),
+	}
+	got, diag := imageSchema.TypeAtPath(context.TODO(), path.Root("id"))
+	assert.False(t, diag.HasError())
+	assert.Equal(t, types.StringType, got)
+}

--- a/internal/cmlschema/node.go
+++ b/internal/cmlschema/node.go
@@ -324,9 +324,10 @@ func newSerialDevice(ctx context.Context, sd cmlclient.SerialDevice, diags *diag
 }
 
 func newTags(ctx context.Context, node *cmlclient.Node, diags *diag.Diagnostics) types.List {
-	if len(node.Tags) == 0 {
-		return types.ListNull(types.StringType)
-	}
+	// Node tags can't be null, there's always a list of tags, even if it's empty
+	// if len(node.Tags) == 0 {
+	// 	return types.ListNull(types.StringType)
+	// }
 	valueList := make([]attr.Value, 0)
 	for _, tag := range node.Tags {
 		valueList = append(valueList, types.StringValue(tag))

--- a/internal/cmlschema/node_test.go
+++ b/internal/cmlschema/node_test.go
@@ -17,17 +17,17 @@ import (
 )
 
 var node *cmlclient.Node = &cmlclient.Node{
-	ID:              "8bf321c3-3312-44f2-9098-fa89e2e05d7e",
-	Label:           "router 1",
-	X:               10,
-	Y:               20,
-	NodeDefinition:  "IOSv",
-	ImageDefinition: "",
-	Configuration:   "hostname router1",
-	CPUs:            0,
-	CPUlimit:        100,
-	RAM:             512,
-	State:           "BOOTED",
+	ID:             "8bf321c3-3312-44f2-9098-fa89e2e05d7e",
+	Label:          "router 1",
+	X:              10,
+	Y:              20,
+	NodeDefinition: "IOSv",
+	// ImageDefinition: "",
+	Configuration: "hostname router1",
+	CPUs:          0,
+	CPUlimit:      100,
+	RAM:           512,
+	State:         "BOOTED",
 	Interfaces: cmlclient.InterfaceList{
 		iface,
 		iface,
@@ -43,6 +43,12 @@ var node *cmlclient.Node = &cmlclient.Node{
 	BootDiskSize: 16,
 	DataVolume:   0,
 }
+
+// func newPtr[V int | string](value V) *V {
+// 	ptr := new(V)
+// 	*ptr = value
+// 	return ptr
+// }
 
 func TestNewNode(t *testing.T) {
 	diag := &diag.Diagnostics{}

--- a/internal/provider/datasource/images/images_test.go
+++ b/internal/provider/datasource/images/images_test.go
@@ -53,7 +53,7 @@ func TestImageDataSource(t *testing.T) {
 func testImageDataSourceConfig(cfg, nd string) string {
 	ndCfg := ""
 	if len(nd) > 0 {
-		ndCfg = fmt.Sprintf("node_definition = %q", nd)
+		ndCfg = fmt.Sprintf("nodedefinition = %q", nd)
 	}
 	return fmt.Sprintf(`
 	%[1]s
@@ -64,7 +64,7 @@ func testImageDataSourceConfig(cfg, nd string) string {
 		il = data.cml2_images.test.image_list
 	}
 	output "bla" {
-		value = element(local.il, length(local.il)-1).node_definition_id
+		value = element(local.il, length(local.il)-1).nodedefinition
 	}
 	`, cfg, ndCfg)
 }

--- a/internal/provider/datasource/images/main.go
+++ b/internal/provider/datasource/images/main.go
@@ -22,7 +22,7 @@ var _ datasource.DataSource = &ImagesDataSource{}
 
 type ImagesDataSourceModel struct {
 	ID        types.String `tfsdk:"id"`
-	NodeDef   types.String `tfsdk:"node_definition"`
+	NodeDef   types.String `tfsdk:"nodedefinition"`
 	ImageList types.List   `tfsdk:"image_list"`
 }
 
@@ -79,19 +79,17 @@ func (d *ImagesDataSource) Configure(ctx context.Context, req datasource.Configu
 }
 
 func (d *ImagesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema.Attributes = cmlschema.ImageDef()
-
 	resp.Schema.Attributes = map[string]schema.Attribute{
 		"id": schema.StringAttribute{
-			Description: "A UUID. The attribute required by the framework.",
+			Description: "A UUID. The presence of the ID attribute is mandated by the framework. The attribute is a random UUID and has no actual significance.",
 			Computed:    true,
 		},
-		"node_definition": schema.StringAttribute{
+		"nodedefinition": schema.StringAttribute{
 			Description: "A node definition ID to filter the image list.",
 			Optional:    true,
 		},
 		"image_list": schema.ListNestedAttribute{
-			MarkdownDescription: "A list of all image definitions available on the controller, potentially filtered by the provided `node_definition` attribute.",
+			MarkdownDescription: "A list of all image definitions available on the controller, potentially filtered by the provided `nodedefinition` attribute.",
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: cmlschema.ImageDef(),
 			},
@@ -99,7 +97,7 @@ func (d *ImagesDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 		},
 	}
 
-	resp.Schema.MarkdownDescription = "A data source that retrieves image definitions from the controller. The optional `node_definition` ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned."
+	resp.Schema.MarkdownDescription = "A data source that retrieves image definitions from the controller. The optional `nodedefinition` ID can be provided to filter the list of image definitions for the specified node definition. If no node definition ID is provided, the complete image definition list known to the controller is returned."
 	resp.Diagnostics = nil
 }
 

--- a/internal/provider/datasource/lab/main.go
+++ b/internal/provider/datasource/lab/main.go
@@ -58,7 +58,7 @@ func (d *LabDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			Computed:    true,
 		},
 	}
-	resp.Schema.MarkdownDescription = "A lab data source. Either the lab `id` or the lab `title` must be provided to retrieve the `lab` data from the controller.  Note that **all** of the attributes of the lab element are read-only even though the auto-generated schema documentation lists some of them as \"optional\"."
+	resp.Schema.MarkdownDescription = "A lab data source. Either the lab `id` or the lab `title` must be provided to retrieve the `lab` data from the controller."
 	resp.Diagnostics = nil
 }
 

--- a/internal/provider/datasource/node/main.go
+++ b/internal/provider/datasource/node/main.go
@@ -58,7 +58,7 @@ func (d *NodeDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			Computed:    true,
 		},
 	}
-	resp.Schema.MarkdownDescription = "A node data source.  Both, the node `id` and the `lab_id` must be provided to retrieve the `node` data from the controller.  Note that **all** of the attributes of the node element are read-only even though the auto-generated schema documentation lists some of them as \"optional\"."
+	resp.Schema.MarkdownDescription = "A node data source.  Both, the node `id` and the `lab_id` must be provided to retrieve the `node` data from the controller."
 	resp.Diagnostics = nil
 }
 

--- a/internal/provider/resource/node/create.go
+++ b/internal/provider/resource/node/create.go
@@ -33,45 +33,46 @@ func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	node.LabID = data.LabID.ValueString()
 
-	if !data.Label.IsNull() {
+	if !data.Label.IsUnknown() {
 		node.Label = data.Label.ValueString()
 	}
-	if !data.NodeDefinition.IsNull() {
+	if !data.NodeDefinition.IsUnknown() {
 		node.NodeDefinition = data.NodeDefinition.ValueString()
 	}
-	if !data.ImageDefinition.IsNull() {
-		node.ImageDefinition = data.ImageDefinition.ValueString()
-	}
-	if !data.Tags.IsNull() {
+	if !data.Tags.IsUnknown() {
 		tags := []string{}
 		for _, tag := range data.Tags.Elements() {
 			tags = append(tags, tag.(types.String).ValueString())
 		}
 		node.Tags = tags
 	}
-	if !data.Configuration.IsNull() {
+	if !data.Configuration.IsUnknown() {
 		node.Configuration = data.Configuration.ValueString()
 	}
-	if !data.X.IsNull() {
+	if !data.X.IsUnknown() {
 		node.X = int(data.X.ValueInt64())
 	}
-	if !data.Y.IsNull() {
+	if !data.Y.IsUnknown() {
 		node.Y = int(data.Y.ValueInt64())
 	}
-	if !data.CPUs.IsNull() {
+
+	if !data.RAM.IsUnknown() {
+		node.RAM = int(data.RAM.ValueInt64())
+	}
+	if !data.CPUs.IsUnknown() {
 		node.CPUs = int(data.CPUs.ValueInt64())
 	}
-	if !data.CPUlimit.IsNull() {
+	if !data.CPUlimit.IsUnknown() {
 		node.CPUlimit = int(data.CPUlimit.ValueInt64())
 	}
-	if !data.BootDiskSize.IsNull() {
+	if !data.BootDiskSize.IsUnknown() {
 		node.BootDiskSize = int(data.BootDiskSize.ValueInt64())
 	}
-	if !data.DataVolume.IsNull() {
+	if !data.DataVolume.IsUnknown() {
 		node.DataVolume = int(data.DataVolume.ValueInt64())
 	}
-	if !data.RAM.IsNull() {
-		node.RAM = int(data.RAM.ValueInt64())
+	if !data.ImageDefinition.IsUnknown() {
+		node.ImageDefinition = data.ImageDefinition.ValueString()
 	}
 
 	newNode, err := r.cfg.Client().NodeCreate(ctx, &node)

--- a/internal/provider/resource/node/create.go
+++ b/internal/provider/resource/node/create.go
@@ -39,13 +39,17 @@ func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !data.NodeDefinition.IsUnknown() {
 		node.NodeDefinition = data.NodeDefinition.ValueString()
 	}
-	if !data.Tags.IsUnknown() {
-		tags := []string{}
-		for _, tag := range data.Tags.Elements() {
-			tags = append(tags, tag.(types.String).ValueString())
-		}
-		node.Tags = tags
+
+	// We always need to create a tag list as the API always returns a list of
+	// tags even if none are set... e.g. no tags --> [] (instead of null).
+	// if !data.Tags.IsUnknown() {
+	tags := []string{}
+	for _, tag := range data.Tags.Elements() {
+		tags = append(tags, tag.(types.String).ValueString())
 	}
+	node.Tags = tags
+	// }
+
 	if !data.Configuration.IsUnknown() {
 		node.Configuration = data.Configuration.ValueString()
 	}

--- a/internal/provider/resource/node/modify_plan.go
+++ b/internal/provider/resource/node/modify_plan.go
@@ -143,6 +143,15 @@ func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		planData.BootDiskSize = types.Int64Null()
 	}
 
+	// need to set an empty list if no configuration is provided for tags
+	// this is a one-off since tags can't be null
+	if configData.Tags.IsNull() {
+		tags, dia := types.ListValueFrom(ctx, types.StringType, []string{})
+		planData.Tags = tags
+		resp.Diagnostics.Append(dia...)
+		// types.ListNull(types.ObjectType{AttrTypes: cmlschema.InterfaceAttrType})
+	}
+
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &planData)...)
 
 	tflog.Info(ctx, "Resource Node MODIFYPLAN done")

--- a/internal/provider/resource/node/modify_plan.go
+++ b/internal/provider/resource/node/modify_plan.go
@@ -115,7 +115,8 @@ func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("cpu_limit"))
 		}
 		planData.CPUlimit = configData.CPUlimit
-	} else {
+	}
+	if planData.CPUs.IsUnknown() {
 		// CPUlimit is the weird one here as it is possible to set the value to null
 		// and this actually works on updating on the controller (PATCH). However,
 		// when reading the data again, the value comes back as 100.

--- a/internal/provider/resource/node/modify_plan.go
+++ b/internal/provider/resource/node/modify_plan.go
@@ -3,9 +3,11 @@ package node
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	cmlclient "github.com/rschmied/gocmlclient"
 	"github.com/rschmied/terraform-provider-cml2/internal/cmlschema"
 )
 
@@ -31,45 +33,114 @@ import (
 func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 
 	// var stateData, planData cmlschema.NodeModel
-	var planData cmlschema.NodeModel
+	var configData, planData, stateData cmlschema.NodeModel
 
 	tflog.Info(ctx, "Resource Node MODIFYPLAN")
 
 	// when deleting, there's no plan
-	if req.Plan.Raw.IsNull() {
-		tflog.Info(ctx, "there is no plan")
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		tflog.Info(ctx, "there is no plan or state")
 		return
 	}
 
-	// Read Terraform plan data into the model
+	// Read Terraform config/plan/state data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	if planData.DataVolume.IsUnknown() {
-		planData.DataVolume = types.Int64Null()
-	}
-	if planData.BootDiskSize.IsUnknown() {
-		planData.BootDiskSize = types.Int64Null()
-	}
+	// if the node was started once (e.g. not in state DEFINED anymore) then
+	// changing certain attributes require a replace
+	nodeExists := stateData.State.ValueString() != cmlclient.NodeStateDefined
+
 	if planData.ComputeID.IsUnknown() {
 		planData.ComputeID = types.StringNull()
-	}
-	if planData.ImageDefinition.IsUnknown() {
-		planData.ImageDefinition = types.StringNull()
 	}
 	if planData.SerialDevices.IsUnknown() {
 		planData.SerialDevices = types.ListNull(cmlschema.SerialDevicesAttrType)
 	}
+	if planData.VNCkey.IsUnknown() {
+		planData.VNCkey = types.StringNull()
+	}
+	if planData.Interfaces.IsUnknown() {
+		planData.Interfaces = types.ListNull(types.ObjectType{AttrTypes: cmlschema.InterfaceAttrType})
+	}
+
+	// the following are the attributes where the replace is depending on
+	// the node state...
+	if !planData.Configuration.IsUnknown() && nodeExists {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("configuration"))
+	}
+
+	if !configData.ImageDefinition.IsNull() && !configData.ImageDefinition.Equal(stateData.ImageDefinition) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("imagedefinition"))
+		}
+		planData.ImageDefinition = configData.ImageDefinition
+	}
+	if planData.ImageDefinition.IsUnknown() {
+		planData.ImageDefinition = types.StringNull()
+	}
+
+	if !configData.RAM.IsNull() && !configData.RAM.Equal(stateData.RAM) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("ram"))
+		}
+		planData.RAM = configData.RAM
+	}
 	if planData.RAM.IsUnknown() {
 		planData.RAM = types.Int64Null()
+	}
+
+	if !configData.CPUs.IsNull() && !configData.CPUs.Equal(stateData.CPUs) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("cpus"))
+		}
+		planData.CPUs = configData.CPUs
 	}
 	if planData.CPUs.IsUnknown() {
 		planData.CPUs = types.Int64Null()
 	}
-	if planData.VNCkey.IsUnknown() {
-		planData.VNCkey = types.StringNull()
+
+	if !configData.CPUlimit.IsNull() && !configData.CPUlimit.Equal(stateData.CPUlimit) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("cpu_limit"))
+		}
+		planData.CPUlimit = configData.CPUlimit
+	} else {
+		// CPUlimit is the weird one here as it is possible to set the value to null
+		// and this actually works on updating on the controller (PATCH). However,
+		// when reading the data again, the value comes back as 100.
+		// See SIMPLE-5052 and cmlclient.NodeGet()
+		planData.CPUlimit = types.Int64Value(int64(100))
+	}
+
+	if !configData.DataVolume.IsNull() && !configData.DataVolume.Equal(stateData.DataVolume) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("data_volume"))
+		}
+		planData.DataVolume = configData.DataVolume
+	}
+	if planData.DataVolume.IsUnknown() {
+		planData.DataVolume = types.Int64Null()
+	}
+
+	if !configData.BootDiskSize.IsNull() && !configData.BootDiskSize.Equal(stateData.BootDiskSize) {
+		if nodeExists {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("boot_disk_size"))
+		}
+		planData.BootDiskSize = configData.BootDiskSize
+	}
+	if planData.BootDiskSize.IsUnknown() {
+		planData.BootDiskSize = types.Int64Null()
 	}
 
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &planData)...)

--- a/internal/provider/resource/node/node_test.go
+++ b/internal/provider/resource/node/node_test.go
@@ -97,6 +97,67 @@ func TestAccNodeResource(t *testing.T) {
 	})
 }
 
+func TestAccNodeResourceTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "0"),
+					// resource.TestCheckNoResourceAttr("cml2_node.r1", "tags"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "2"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.0", "test"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.1", "tag2"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "1"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.0", "tag2"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "0"),
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				// resource.TestCheckNoResourceAttr("cml2_node.r1", "tags"),
+			},
+			{
+				// need to re-run to apply the change
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "0"),
+				),
+				// resource.TestCheckNoResourceAttr("cml2_node.r1", "tags"),
+			},
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "0"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfigTags(cfg.Cfg, 6),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "0"),
+					// resource.TestCheckNoResourceAttr("cml2_node.r1", "tags"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNodeResourceConfigNodeDefInvalid(cfg string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -165,6 +226,45 @@ func testAccNodeResourceConfig(cfg string, step int) string {
 		`, cfg)
 	}
 	panic("undefined step!")
+}
+
+// 	tagline := ""
+// 	if len(tags) > 0 {
+// 		for idx, tag := range tags {
+// 			tags[idx] = fmt.Sprintf("%q", tag)
+// 		}
+// 		tagline = fmt.Sprintf("tags = [%s]\n", strings.Join(tags, ","))
+// 	}
+
+func testAccNodeResourceConfigTags(cfg string, step int) string {
+	var tags string
+	switch step {
+	case 1:
+		tags = ""
+	case 2:
+		tags = "tags = [ \"test\", \"tag2\" ]"
+	case 3:
+		tags = "tags = [ \"tag2\" ]"
+	case 4:
+		tags = ""
+	case 5:
+		tags = "tags = [ ]"
+	case 6:
+		tags = ""
+	default:
+		panic("undefined step!")
+	}
+	return fmt.Sprintf(`
+	%[1]s
+	resource "cml2_lab" "test" {
+	}
+	resource "cml2_node" "r1" {
+		lab_id          = cml2_lab.test.id
+		label           = "alpine-0"
+		nodedefinition  = "alpine"
+		%[2]s
+	}
+	`, cfg, tags)
 }
 
 // 	tagline := ""

--- a/internal/provider/resource/node/node_test.go
+++ b/internal/provider/resource/node/node_test.go
@@ -28,31 +28,44 @@ func testAccPreCheck(t *testing.T) {
 
 func TestAccNodeResource(t *testing.T) {
 	re1 := regexp.MustCompile(`Node Definition not found:`)
-	re2 := regexp.MustCompile(`expected "alpine", got "iosv"`)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
-				Config:      testAccNodeResourceConfig(cfg.Cfg, "doesntexist"),
+				Config:      testAccNodeResourceConfigNodeDefInvalid(cfg.Cfg),
 				ExpectError: re1,
 			},
 			{
-				Config: testAccNodeResourceConfig(cfg.Cfg, "alpine"),
+				Config: testAccNodeResourceConfig(cfg.Cfg, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cml2_node.r1", "nodedefinition", "alpine"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "label", "alpine-0"),
 					resource.TestCheckNoResourceAttr("cml2_node.r1", "imagedefinition"),
-					resource.TestCheckResourceAttr("cml2_node.r1", "x", "98"),
-					resource.TestCheckResourceAttr("cml2_node.r1", "y", "99"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "x", "100"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "y", "100"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "1"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "tags.0", "test"),
 				),
 			},
 			{
-				Config: testAccNodeResourceConfig2(cfg.Cfg),
+				// ExpectNonEmptyPlan: true,
+				Config: testAccNodeResourceConfig(cfg.Cfg, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cml2_node.r1", "nodedefinition", "alpine"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "label", "alpine-99"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "x", "100"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "y", "200"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "2"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.0", "test"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.1", "tag2"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfig(cfg.Cfg, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.r1", "nodedefinition", "alpine"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "label", "alpine-99"),
 					resource.TestCheckResourceAttrSet("cml2_node.r1", "imagedefinition"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "x", "100"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "y", "200"),
@@ -62,15 +75,8 @@ func TestAccNodeResource(t *testing.T) {
 					resource.TestCheckResourceAttr("cml2_node.r1", "data_volume", "64"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "tags.#", "2"),
 					resource.TestCheckResourceAttr("cml2_node.r1", "tags.0", "test"),
-					resource.TestCheckResourceAttr("cml2_node.r1", "tags.1", "someothertag"),
+					resource.TestCheckResourceAttr("cml2_node.r1", "tags.1", "tag2"),
 				),
-			},
-			{
-				Config: testAccNodeResourceConfig(cfg.Cfg, "iosv"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("cml2_node.r1", "nodedefinition", "alpine"),
-				),
-				ExpectError: re2,
 			},
 			// ImportState testing
 			// {
@@ -91,22 +97,7 @@ func TestAccNodeResource(t *testing.T) {
 	})
 }
 
-func TestAccLifecycleNodeProps(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNodeResourceRam(cfg.Cfg),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("cml2_node.r1", "ram", "512"),
-				),
-			},
-		},
-	})
-}
-
-func testAccNodeResourceConfig(cfg, node_def string) string {
+func testAccNodeResourceConfigNodeDefInvalid(cfg string) string {
 	return fmt.Sprintf(`
 %[1]s
 resource "cml2_lab" "test" {
@@ -114,52 +105,72 @@ resource "cml2_lab" "test" {
 resource "cml2_node" "r1" {
 	lab_id         = cml2_lab.test.id
 	label          = "r1"
-	nodedefinition = "%[2]s"
-	x              = 98
-	y              = 99
-	tags           = ["test"]
-}
-`, cfg, node_def)
-}
-
-func testAccNodeResourceConfig2(cfg string) string {
-	return fmt.Sprintf(`
-%[1]s
-data "cml2_images" "test" {
-	node_definition = "alpine"
-}
-resource "cml2_lab" "test" {
-}
-resource "cml2_node" "r1" {
-	lab_id          = cml2_lab.test.id
-	label           = "r1"
-	x               = 100
-	y               = 200
-	ram             = 1024
-	cpus            = 2
-	nodedefinition  = "alpine"
-	imagedefinition = element(data.cml2_images.test.image_list, 0).id
-	boot_disk_size  = 64
-	data_volume     = 64
-	tags            = ["test", "someothertag"]
+	nodedefinition = "invalid"
 }
 `, cfg)
 }
 
-func testAccNodeResourceRam(cfg string) string {
-	return fmt.Sprintf(`
-%[1]s
-resource "cml2_lab" "test" {
+func testAccNodeResourceConfig(cfg string, step int) string {
+	if step == 1 {
+		return fmt.Sprintf(`
+		%[1]s
+		resource "cml2_lab" "test" {
+		}
+		resource "cml2_node" "r1" {
+			lab_id          = cml2_lab.test.id
+			label           = "alpine-0"
+			x               = 100
+			y               = 100
+			nodedefinition  = "alpine"
+			tags            = [ "test" ]
+		}
+		`, cfg)
+	}
+	if step == 2 {
+		return fmt.Sprintf(`
+		%[1]s
+		resource "cml2_lab" "test" {
+		}
+		resource "cml2_node" "r1" {
+			lab_id          = cml2_lab.test.id
+			label           = "alpine-99"
+			x               = 100
+			y               = 200
+			nodedefinition  = "alpine"
+			tags            = [ "test", "tag2" ]
+		}
+		`, cfg)
+	}
+	if step == 3 {
+		return fmt.Sprintf(`
+		%[1]s
+		data "cml2_images" "test" {
+			nodedefinition = "alpine"
+		}
+		resource "cml2_lab" "test" {
+		}
+		resource "cml2_node" "r1" {
+			lab_id          = cml2_lab.test.id
+			label           = "alpine-99"
+			x               = 100
+			y               = 200
+			nodedefinition  = "alpine"
+			imagedefinition = element(data.cml2_images.test.image_list, 0).id
+			ram             = 1024
+			cpus            = 2
+			boot_disk_size  = 64
+			data_volume     = 64
+			tags            = [ "test", "tag2" ]
+		}
+		`, cfg)
+	}
+	panic("undefined step!")
 }
 
-resource "cml2_node" "r1" {
-  lab_id         = cml2_lab.test.id
-  label          = "R1"
-  ram            = 512
-  boot_disk_size = 64
-  cpus           = 2
-  cpu_limit      = 80
-  nodedefinition = "alpine"
-}
-`, cfg)
-}
+// 	tagline := ""
+// 	if len(tags) > 0 {
+// 		for idx, tag := range tags {
+// 			tags[idx] = fmt.Sprintf("%q", tag)
+// 		}
+// 		tagline = fmt.Sprintf("tags = [%s]\n", strings.Join(tags, ","))
+// 	}

--- a/internal/provider/resource/node/node_test.go
+++ b/internal/provider/resource/node/node_test.go
@@ -26,6 +26,18 @@ func testAccPreCheck(t *testing.T) {
 	// are common to see in a pre-check function.
 }
 
+func TestAccNodeResourceCreateAllAttrs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeResourceCreateAllAttrs(cfg.Cfg),
+			},
+		},
+	})
+}
+
 func TestAccNodeResource(t *testing.T) {
 	re1 := regexp.MustCompile(`Node Definition not found:`)
 	resource.Test(t, resource.TestCase{
@@ -169,6 +181,32 @@ resource "cml2_node" "r1" {
 	nodedefinition = "invalid"
 }
 `, cfg)
+}
+
+func testAccNodeResourceCreateAllAttrs(cfg string) string {
+	return fmt.Sprintf(`
+		%[1]s
+		data "cml2_images" "test" {
+			nodedefinition = "alpine"
+		}
+		resource "cml2_lab" "test" {
+		}
+		resource "cml2_node" "r1" {
+			lab_id          = cml2_lab.test.id
+			label           = "alpine-0"
+			x               = 100
+			y               = 100
+			nodedefinition  = "alpine"
+			tags            = [ "test" ]
+			configuration   = "hostname bla"
+			ram             = 2048
+			cpus            = 2
+			cpu_limit       = 90
+			boot_disk_size  = 64
+			data_volume     = 64
+			imagedefinition = element(data.cml2_images.test.image_list, 0).id
+		}
+		`, cfg)
 }
 
 func testAccNodeResourceConfig(cfg string, step int) string {

--- a/internal/provider/resource/node/update.go
+++ b/internal/provider/resource/node/update.go
@@ -51,8 +51,6 @@ func (r NodeResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		var tag types.String
 		tags := []string{}
 		for _, elem := range planData.Tags.Elements() {
-			// Ignore error and diagnostics for the simple conversion here
-			// Can't use elem.String() here as that has the value in quotes!
 			tfsdk.ValueAs(ctx, elem, &tag)
 			tags = append(tags, tag.ValueString())
 		}

--- a/internal/provider/resource/node/update.go
+++ b/internal/provider/resource/node/update.go
@@ -35,6 +35,7 @@ func (r NodeResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	node := &cmlclient.Node{
 		ID:    planData.ID.ValueString(),
 		LabID: planData.LabID.ValueString(),
+		State: planData.State.ValueString(),
 	}
 
 	if !planData.X.IsNull() {
@@ -59,26 +60,26 @@ func (r NodeResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	// these can only be changed when the node is DEFINED_ON_CORE
-	if stateData.State.ValueString() == cmlclient.LabStateDefined {
-		if !planData.Configuration.IsNull() {
+	if stateData.State.ValueString() == cmlclient.NodeStateDefined {
+		if !planData.Configuration.IsUnknown() {
 			node.Configuration = planData.Configuration.ValueString()
 		}
-		if !planData.RAM.IsNull() {
+		if !planData.RAM.IsUnknown() {
 			node.RAM = int(planData.RAM.ValueInt64())
 		}
-		if !planData.CPUs.IsNull() {
+		if !planData.CPUs.IsUnknown() {
 			node.CPUs = int(planData.CPUs.ValueInt64())
 		}
-		if !planData.CPUlimit.IsNull() {
+		if !planData.CPUlimit.IsUnknown() {
 			node.CPUlimit = int(planData.CPUlimit.ValueInt64())
 		}
-		if !planData.BootDiskSize.IsNull() {
+		if !planData.BootDiskSize.IsUnknown() {
 			node.BootDiskSize = int(planData.BootDiskSize.ValueInt64())
 		}
-		if !planData.DataVolume.IsNull() {
+		if !planData.DataVolume.IsUnknown() {
 			node.DataVolume = int(planData.DataVolume.ValueInt64())
 		}
-		if !planData.ImageDefinition.IsNull() {
+		if !planData.ImageDefinition.IsUnknown() {
 			node.ImageDefinition = planData.ImageDefinition.ValueString()
 		}
 	}


### PR DESCRIPTION
- allow change of more properties when node hasn't been started yet
- for image definition data source: change the attribute name of the node definition filter from `node_definition_id` to `nodedefinition` for consistency
- improve test coverage
- documentation improvements
- dependency updates