### PR TITLE
allow late config binding (dynamic_config flag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Lists the changes in the provider.
 
+## Version 0.6.1
+
+- allow dynamic configuration of the provider by introducing a "dynamic_config"
+  provider config flag. This defaults to `false`. When set to `true` then the
+  provider configuration is only validated when actual resources are read or
+  created. This is for specific use cases like AWS deployments where the CML2
+  instance IP is only known after the EC2 instance has been created.
+- bump the gocmlclient to 0.0.18
+
 ## Version 0.6.0
 
 - allow empty node configurations (fixes #50)

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ provider "cml2" {
 ### Optional
 
 - `cacert` (String) A CA CERT, PEM encoded. When provided, the controller cert will be checked against it.  Otherwise, the system trust anchors will be used.
+- `dynamic_config` (Boolean) Does late binding of the provider configuration. If set to `true` then provider configuration errors will only be caught when resources and data sources are actually created/read. Defaults to `false`
 - `password` (String, Sensitive) CML2 password.
 - `skip_verify` (Boolean) Disables TLS certificate verification (default is false -- will not skip / it will verify the certificate!)
 - `token` (String, Sensitive) CML2 API token (JWT).

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.15.0
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
-	github.com/rschmied/gocmlclient v0.0.18
+	github.com/rschmied/gocmlclient v0.0.19
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.15.0
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
-	github.com/rschmied/gocmlclient v0.0.17
+	github.com/rschmied/gocmlclient v0.0.18
 	github.com/stretchr/testify v1.8.2
 )
 
@@ -58,7 +58,6 @@ require (
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,10 +146,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
-github.com/rschmied/gocmlclient v0.0.16 h1:dWlXb4IJfwyuEqfI1/8RbebKHe+CkBEBsthq61NI6pY=
-github.com/rschmied/gocmlclient v0.0.16/go.mod h1:j5oDyPNNiM/Q1rOE3IKqTJW2lt5ANDcGPolWyr9ddMc=
-github.com/rschmied/gocmlclient v0.0.17 h1:I2G6jo4O6gkhME19QIIgzuE0WE25P3NFyOKWxGQPFuM=
-github.com/rschmied/gocmlclient v0.0.17/go.mod h1:AxuKqPKsWwqRtThJk5Ozi8B2Hp7/dR/A94zDq3gLQ90=
+github.com/rschmied/gocmlclient v0.0.18 h1:elHifXY4+4rjDujCwd2VRDt8m+Xn1y0coihx676qVHk=
+github.com/rschmied/gocmlclient v0.0.18/go.mod h1:AxuKqPKsWwqRtThJk5Ozi8B2Hp7/dR/A94zDq3gLQ90=
 github.com/rschmied/mockresponder v1.0.4 h1:VFXa9Y9QJ/5oZFhKoqh9u3HQlbjcBfE9pxI+BanMlEs=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
-github.com/rschmied/gocmlclient v0.0.18 h1:elHifXY4+4rjDujCwd2VRDt8m+Xn1y0coihx676qVHk=
-github.com/rschmied/gocmlclient v0.0.18/go.mod h1:AxuKqPKsWwqRtThJk5Ozi8B2Hp7/dR/A94zDq3gLQ90=
+github.com/rschmied/gocmlclient v0.0.19 h1:mrC2boo67juuzJPCinmV9EIu8Dlwm9n0vii3vQUePhQ=
+github.com/rschmied/gocmlclient v0.0.19/go.mod h1:AxuKqPKsWwqRtThJk5Ozi8B2Hp7/dR/A94zDq3gLQ90=
 github.com/rschmied/mockresponder v1.0.4 h1:VFXa9Y9QJ/5oZFhKoqh9u3HQlbjcBfE9pxI+BanMlEs=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/internal/cmlschema/provider.go
+++ b/internal/cmlschema/provider.go
@@ -7,13 +7,14 @@ import (
 
 // ProviderModel describes the provider configuration data model.
 type ProviderModel struct {
-	Address    types.String `tfsdk:"address"`
-	Username   types.String `tfsdk:"username"`
-	Password   types.String `tfsdk:"password"`
-	Token      types.String `tfsdk:"token"`
-	CAcert     types.String `tfsdk:"cacert"`
-	SkipVerify types.Bool   `tfsdk:"skip_verify"`
-	UseCache   types.Bool   `tfsdk:"use_cache"`
+	Address       types.String `tfsdk:"address"`
+	Username      types.String `tfsdk:"username"`
+	Password      types.String `tfsdk:"password"`
+	Token         types.String `tfsdk:"token"`
+	CAcert        types.String `tfsdk:"cacert"`
+	SkipVerify    types.Bool   `tfsdk:"skip_verify"`
+	UseCache      types.Bool   `tfsdk:"use_cache"`
+	DynamicConfig types.Bool   `tfsdk:"dynamic_config"`
 }
 
 func Provider() map[string]schema.Attribute {
@@ -48,6 +49,10 @@ func Provider() map[string]schema.Attribute {
 		"use_cache": schema.BoolAttribute{
 			Description: "Enables the client cache, this is considered experimental (default is false -- will not use the cache!)",
 			Optional:    true,
+		},
+		"dynamic_config": schema.BoolAttribute{
+			MarkdownDescription: "Does late binding of the provider configuration. If set to `true` then provider configuration errors will only be caught when resources and data sources are actually created/read. Defaults to `false`",
+			Optional:            true,
 		},
 	}
 }

--- a/internal/cmlschema/provider_test.go
+++ b/internal/cmlschema/provider_test.go
@@ -18,7 +18,7 @@ func TestProviderAttrs(t *testing.T) {
 
 	got, diag := schema.TypeAtPath(context.TODO(), path.Root("address"))
 	assert.Equal(t, types.StringType, got)
-	assert.Equal(t, 7, len(schema.Attributes))
+	assert.Equal(t, 8, len(schema.Attributes))
 	assert.False(t, diag.HasError())
 	t.Log(diag.Errors())
 }

--- a/internal/common/configure.go
+++ b/internal/common/configure.go
@@ -6,12 +6,17 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	cmlclient "github.com/rschmied/gocmlclient"
+	"github.com/rschmied/terraform-provider-cml2/internal/cmlschema"
 )
 
 type ProviderConfig struct {
 	client *cmlclient.Client
+	data   *cmlschema.ProviderModel
 	mu     *sync.Mutex
 }
 
@@ -27,11 +32,93 @@ func (r *ProviderConfig) Unlock() {
 	r.mu.Unlock()
 }
 
-func NewProviderConfig(client *cmlclient.Client) *ProviderConfig {
+func NewProviderConfig(data *cmlschema.ProviderModel) *ProviderConfig {
 	return &ProviderConfig{
-		client: client,
+		client: nil,
 		mu:     new(sync.Mutex),
+		data:   data,
 	}
+}
+
+func (r *ProviderConfig) Initialize(ctx context.Context, data *cmlschema.ProviderModel, diag diag.Diagnostics) *ProviderConfig {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.client != nil {
+		return r
+	}
+
+	// check if provided auth configuration makes sense
+	if data.Token.IsNull() &&
+		(data.Username.IsNull() || data.Password.IsNull()) {
+		diag.AddError(
+			"Required configuration missing",
+			"null check: either username and password or a token must be provided",
+		)
+	}
+
+	if len(data.Token.ValueString()) == 0 &&
+		(len(data.Username.ValueString()) == 0 || len(data.Password.ValueString()) == 0) {
+		diag.AddError(
+			"Required configuration missing",
+			"value check: either username and password or a token must be provided",
+		)
+	}
+
+	if len(data.Token.ValueString()) > 0 && len(data.Username.ValueString()) > 0 {
+		diag.AddWarning(
+			"Conflicting configuration",
+			"both token and username / password were provided")
+	}
+
+	// an address must be specified
+	if len(data.Address.ValueString()) == 0 {
+		diag.AddError(
+			"Required configuration missing",
+			"A server address must be configured to use th CML2 provider",
+		)
+	}
+	if data.SkipVerify.IsNull() {
+		tflog.Warn(ctx, "unspecified certificate verification, will verify")
+		data.SkipVerify = types.BoolValue(false)
+	}
+
+	if data.UseCache.IsNull() {
+		data.UseCache = types.BoolValue(false)
+	} else if data.UseCache.ValueBool() {
+		diag.AddWarning(
+			"Experimental feature enabled",
+			"\"use_cache\" is considered experimental and may not work as expected; use with care",
+		)
+	}
+
+	// create a new CML2 client
+	client := cmlclient.New(
+		data.Address.ValueString(),
+		data.SkipVerify.ValueBool(),
+		data.UseCache.ValueBool(),
+	)
+	if len(data.Username.ValueString()) > 0 {
+		client.SetUsernamePassword(
+			data.Username.ValueString(),
+			data.Password.ValueString(),
+		)
+	}
+	if len(data.Token.ValueString()) > 0 {
+		client.SetToken(data.Token.ValueString())
+	}
+
+	if len(data.CAcert.ValueString()) > 0 {
+		err := client.SetCACert([]byte(data.CAcert.ValueString()))
+		if err != nil {
+			diag.AddError(
+				"Configuration issue",
+				fmt.Sprintf("Provided certificate could not be used: %s", err),
+			)
+		}
+	}
+	r.client = client
+	return r
 }
 
 func DatasourceConfigure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *ProviderConfig {
@@ -47,7 +134,7 @@ func DatasourceConfigure(ctx context.Context, req datasource.ConfigureRequest, r
 		)
 		return nil
 	}
-	return config
+	return config.Initialize(ctx, config.data, resp.Diagnostics)
 }
 
 func ResourceConfigure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) *ProviderConfig {
@@ -64,5 +151,5 @@ func ResourceConfigure(ctx context.Context, req resource.ConfigureRequest, resp 
 		)
 		return nil
 	}
-	return config
+	return config.Initialize(ctx, config.data, resp.Diagnostics)
 }


### PR DESCRIPTION
allow dynamic configuration of the provider by introducing a "dynamic_config"
  provider config flag. This defaults to `false`. When set to `true` then the
  provider configuration is only validated when actual resources are read or
  created. This is for specific use cases like AWS deployments where the CML2
  instance IP is only known after the EC2 instance has been created.