### PR TITLE
fix(node): keep explicit named configs, avoid collapsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.1
 
       # This uses an action (hashicorp/ghaction-import-gpg) that assumes you
       # set your private key in the `GPG_PRIVATE_KEY` secret and passphrase
@@ -42,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/internal/cmlschema/node.go
+++ b/internal/cmlschema/node.go
@@ -406,12 +406,15 @@ func newTags(_ context.Context, node *models.Node, diags *diag.Diagnostics) type
 // NewNamedConfigs converts node named configurations into a Terraform list.
 func NewNamedConfigs(ctx context.Context, node *models.Node, diags *diag.Diagnostics) types.List {
 	if len(node.Configurations) == 0 {
-		// For some node definitions (e.g. unmanaged_switch) the API provides a
-		// default named config even if the client did not request named configs.
-		// Returning null for empty keeps state stable.
+		// Return null only when the API has no named configs at all.
+		// Keep explicit named configs (including a single "default" entry) so
+		// user-managed `configurations` does not collapse into `configuration`.
 		return types.ListNull(NamedConfigAttrType)
 	}
-	if len(node.Configurations) == 1 && node.Configurations[0].Name == "default" {
+	if node.NodeDefinition == "unmanaged_switch" && len(node.Configurations) == 1 && node.Configurations[0].Name == "default" {
+		// Controller-managed unmanaged switch bridge defaults are not user-managed
+		// named configs. Keep lifecycle/resource state stable by suppressing this
+		// synthetic default entry.
 		return types.ListNull(NamedConfigAttrType)
 	}
 	valueList := make([]attr.Value, 0)

--- a/internal/provider/resource/node/create.go
+++ b/internal/provider/resource/node/create.go
@@ -19,11 +19,17 @@ import (
 func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var (
 		data            cmlschema.NodeModel
+		configData      cmlschema.NodeModel
 		err             error
 		extConnStateCfg string
 	)
 
 	tflog.Info(ctx, "Resource Node CREATE")
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -31,7 +37,7 @@ func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// ensure named configs are only used when configured!
-	if len(data.Configurations.Elements()) > 0 && !r.cfg.UseNamedConfigs() {
+	if len(configData.Configurations.Elements()) > 0 && !r.cfg.UseNamedConfigs() {
 		resp.Diagnostics.AddError(
 			"Node config conflict",
 			"Provider option \"named_configs\" required to use named configurations!",
@@ -42,7 +48,7 @@ func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, r
 	// tflog.Info(ctx, "CFG", map[string]any{"v": fmt.Sprintf("%+v", data.Configuration.IsUnknown())})
 
 	// can't configure both at the same time!
-	if len(data.Configurations.Elements()) > 0 && !data.Configuration.IsUnknown() {
+	if len(configData.Configurations.Elements()) > 0 && !configData.Configuration.IsUnknown() && !configData.Configuration.IsNull() {
 		resp.Diagnostics.AddError(
 			"Node config conflict",
 			"Can't provide both, configuration and configurations",
@@ -177,7 +183,7 @@ func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// WAS UNKNOWN??
 	// tflog.Warn(ctx, "###2", map[string]any{"null": data.Configuration.IsNull(), "unknown": data.Configuration.IsUnknown(), "len": len(node.Configurations)})
-	if !data.Configuration.IsUnknown() && len(newNode.Configurations) > 0 {
+	if !data.Configuration.IsUnknown() && !data.Configuration.IsNull() && len(newNode.Configurations) > 0 {
 		newNode.Configuration = newNode.Configurations[0].Content
 		newNode.Configurations = nil
 	}

--- a/internal/provider/resource/node/modify_plan.go
+++ b/internal/provider/resource/node/modify_plan.go
@@ -87,6 +87,14 @@ func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("configurations"))
 	}
 
+	// If explicit named configurations are configured, make the single
+	// configuration value null in the plan. Otherwise UseStateForUnknown may pin
+	// it to a prior value (for example "NAT"), which would conflict with the
+	// post-apply state shape when only `configurations` is managed.
+	if !configData.Configurations.IsNull() && !configData.Configurations.IsUnknown() && configData.Configuration.IsNull() {
+		planData.Configuration = cmlschema.NewConfigNull()
+	}
+
 	if !configData.Priority.IsNull() && !configData.Priority.Equal(stateData.Priority) {
 		planData.Priority = configData.Priority
 	}

--- a/internal/provider/resource/node/node_test.go
+++ b/internal/provider/resource/node/node_test.go
@@ -292,6 +292,52 @@ func TestAccNodeResourceExtConn(t *testing.T) {
 	})
 }
 
+func TestAccNodeResourceExtConnNamedConfigCreate(t *testing.T) {
+	cfg.SkipUnlessAcc(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeResourceConfigNodeDefExtConnNamed(cfg.CfgNamedConfigs, "NAT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("cml2_node.ext", "configuration"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.#", "1"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.0.name", "default"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.0.content", "NAT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNodeResourceExtConnNamedConfigTransition(t *testing.T) {
+	cfg.SkipUnlessAcc(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeResourceConfigNodeDefExtConn(cfg.CfgNamedConfigs, "NAT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cml2_node.ext", "configuration", "NAT"),
+				),
+			},
+			{
+				Config: testAccNodeResourceConfigNodeDefExtConnNamed(cfg.CfgNamedConfigs, "NAT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("cml2_node.ext", "configuration"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.#", "1"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.0.name", "default"),
+					resource.TestCheckResourceAttr("cml2_node.ext", "configurations.0.content", "NAT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNodeResourceNamedConfig(t *testing.T) {
 	cfg.SkipUnlessAcc(t)
 
@@ -399,6 +445,25 @@ resource "cml2_node" "ext" {
 	%[2]s
 }
 `, cfg, config)
+}
+
+func testAccNodeResourceConfigNodeDefExtConnNamed(cfg, extconnName string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "cml2_lab" "test" {
+}
+resource "cml2_node" "ext" {
+	lab_id         = cml2_lab.test.id
+	label          = "ext0"
+	nodedefinition = "external_connector"
+	configurations = [
+		{
+			name    = "default"
+			content = %[2]q
+		},
+	]
+}
+`, cfg, extconnName)
 }
 
 func testAccNodeResourceConfigNodeDefInvalid(cfg string) string {

--- a/internal/provider/resource/node/update.go
+++ b/internal/provider/resource/node/update.go
@@ -72,7 +72,7 @@ func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// these can only be changed when the node is DEFINED_ON_CORE
 	if stateData.State.ValueString() == string(models.NodeStateDefined) {
-		if !planData.Configuration.IsUnknown() && !planData.Configuration.IsNull() {
+		if !planData.Configuration.IsUnknown() && !planData.Configuration.IsNull() && planData.Configurations.IsNull() {
 			cfgVal := planData.Configuration.ValueString()
 			if node.NodeDefinition == "external_connector" {
 				normalized, changed, warn, nerr := normalizeExtConnConfig(ctx, r.cfg, cfgVal)
@@ -138,7 +138,7 @@ func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// External connector back-compat: if the user provided a device name (e.g.
 	// "virbr0"), keep the config value in state to match the user's config.
 	// We still sent the normalized label to the API.
-	if node.NodeDefinition == "external_connector" && !planData.Configuration.IsUnknown() && !planData.Configuration.IsNull() {
+	if node.NodeDefinition == "external_connector" && !planData.Configuration.IsUnknown() && !planData.Configuration.IsNull() && planData.Configurations.IsNull() {
 		inCfg := planData.Configuration.ValueString()
 		_, changed, _, _ := normalizeExtConnConfig(ctx, r.cfg, inCfg)
 		if changed {
@@ -153,7 +153,7 @@ func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// When updating with named configs on, we need to move over the returned
 	// named config into the single configuration if it was previously used.
 	// tflog.Warn(ctx, "###u", map[string]any{"null": stateData.Configuration.IsNull(), "unknown": stateData.Configuration.IsUnknown(), "len": len(node.Configurations)})
-	if !stateData.Configuration.IsUnknown() && len(newNode.Configurations) > 0 {
+	if !stateData.Configuration.IsUnknown() && !stateData.Configuration.IsNull() && len(newNode.Configurations) > 0 && planData.Configurations.IsNull() {
 		newNode.Configuration = newNode.Configurations[0].Content
 		newNode.Configurations = nil
 	}


### PR DESCRIPTION
- fix ext conn drift
    - internal/cmlschema: NewNamedConfigs returns null only when the API has
      no named configs; stop collapsing a single "default" entry so explicit
      named configs are preserved
    - provider/resource/node (create): read req.Config into configData and
      use it to detect explicit `configurations`; validate provider
      `named_configs` option and error if both `configuration` and
      `configurations` are provided (treat explicit null as not-provided)
    - provider/resource/node (modify_plan): when explicit named configs are
      configured, force the plan's single `configuration` to null to avoid
      UseStateForUnknown pinning prior values and causing a post-apply shape
      mismatch
    - provider/resource/node (update): guard normalization/collapse logic so
      single-configuration paths only run when `configurations` is null;
      preserve external_connector back-compat only for configuration-only
      cases
    - add null checks throughout to avoid treating explicit nulls as
      unknowns and to make intent (config vs configurations) deterministic
-   (test) add test extconn config transition drift
-   (ci) improve release.yml flow