### PR TITLE
fix(node): make extconn normalization robust

### DIFF
--- a/internal/cmlschema/lab_test.go
+++ b/internal/cmlschema/lab_test.go
@@ -54,7 +54,8 @@ func TestLabAttrs(t *testing.T) {
 	assert.Equal(t, 12, len(labschema.Attributes))
 	assert.False(t, diag.HasError())
 	assert.Equal(t, types.StringType, got)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: cmlschema.LabGroupAttrType,

--- a/internal/cmlschema/node_test.go
+++ b/internal/cmlschema/node_test.go
@@ -135,6 +135,14 @@ func TestNewNamedConfigs(t *testing.T) {
 			},
 			1,
 		},
+		{
+			"ums-default-suppressed",
+			&models.Node{
+				NodeDefinition: "unmanaged_switch",
+				Configurations: []models.NodeConfig{{Name: "default", Content: "bridge"}},
+			},
+			0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/common/configure.go
+++ b/internal/common/configure.go
@@ -114,7 +114,8 @@ func (r *ProviderConfig) Initialize(ctx context.Context, diags *diag.Diagnostics
 	if len(r.data.Token.ValueString()) > 0 && len(r.data.Username.ValueString()) > 0 {
 		diags.AddWarning(
 			"Conflicting configuration",
-			"both token and username / password were provided")
+			"both token and username / password were provided",
+		)
 	}
 
 	// an address must be specified

--- a/internal/provider/datasource/groups/groups.go
+++ b/internal/provider/datasource/groups/groups.go
@@ -97,8 +97,10 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 			continue
 		}
 		groupCopy := group
-		groupList = append(groupList, cmlschema.NewGroup(
-			ctx, &groupCopy, &resp.Diagnostics),
+		groupList = append(
+			groupList, cmlschema.NewGroup(
+				ctx, &groupCopy, &resp.Diagnostics,
+			),
 		)
 	}
 

--- a/internal/provider/datasource/images/images.go
+++ b/internal/provider/datasource/images/images.go
@@ -131,8 +131,10 @@ func (d *ImagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		if !data.NodeDef.IsNull() && img.NodeDefID != data.NodeDef.ValueString() {
 			continue
 		}
-		imageList = append(imageList, cmlschema.NewImageDefinition(
-			ctx, &img, &resp.Diagnostics),
+		imageList = append(
+			imageList, cmlschema.NewImageDefinition(
+				ctx, &img, &resp.Diagnostics,
+			),
 		)
 	}
 

--- a/internal/provider/datasource/users/users.go
+++ b/internal/provider/datasource/users/users.go
@@ -97,8 +97,10 @@ func (d *UsersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 			continue
 		}
 		userCopy := user
-		userList = append(userList, cmlschema.NewUser(
-			ctx, &userCopy, &resp.Diagnostics),
+		userList = append(
+			userList, cmlschema.NewUser(
+				ctx, &userCopy, &resp.Diagnostics,
+			),
 		)
 	}
 

--- a/internal/provider/resource/annotation/annotation_test.go
+++ b/internal/provider/resource/annotation/annotation_test.go
@@ -255,7 +255,7 @@ resource "cml2_annotation" "a" {
 `, cfgStr, content, bold)
 }
 
-func testAccAnnotationRectangle(cfgStr string, x1, y1, x2, y2 int, rotation int, borderStyle string) string {
+func testAccAnnotationRectangle(cfgStr string, x1, y1, x2, y2, rotation int, borderStyle string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -280,7 +280,7 @@ resource "cml2_annotation" "a" {
 `, cfgStr, x1, y1, x2, y2, rotation, borderStyle)
 }
 
-func testAccAnnotationEllipse(cfgStr string, x1, y1, x2, y2 int, rotation int) string {
+func testAccAnnotationEllipse(cfgStr string, x1, y1, x2, y2, rotation int) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/internal/provider/resource/annotation/build.go
+++ b/internal/provider/resource/annotation/build.go
@@ -18,7 +18,7 @@ func clampThickness(v float64) float64 {
 	return v
 }
 
-func strOrDefault(v string, def string) string {
+func strOrDefault(v, def string) string {
 	if len(v) == 0 {
 		return def
 	}

--- a/internal/provider/resource/lifecycle/utilities.go
+++ b/internal/provider/resource/lifecycle/utilities.go
@@ -156,7 +156,8 @@ func (r *LabLifecycleResource) injectConfigs(ctx context.Context, lab *models.La
 		configString := config.(types.String).ValueString()
 		err = r.cfg.Client().Node.SetConfig(ctx, node, configString)
 		if err != nil {
-			diags.AddError("set node config failed",
+			diags.AddError(
+				"set node config failed",
 				fmt.Sprintf("setting the new node configuration failed: %s", err),
 			)
 		}
@@ -181,7 +182,8 @@ func (r *LabLifecycleResource) injectConfigs(ctx context.Context, lab *models.La
 		configs := cmlschema.GetNamedConfigs(ctx, *diags, ba)
 		err = r.cfg.Client().Node.SetNamedConfigs(ctx, node, configs)
 		if err != nil {
-			diags.AddError("set node named config failed",
+			diags.AddError(
+				"set node named config failed",
 				fmt.Sprintf("setting the new node configurations failed: %s", err),
 			)
 		}

--- a/internal/provider/resource/node/extconn_normalize.go
+++ b/internal/provider/resource/node/extconn_normalize.go
@@ -21,7 +21,22 @@ func normalizeExtConnConfig(ctx context.Context, cfg *common.ProviderConfig, in 
 		return "", false, "", nil
 	}
 
-	connectors, err := cfg.Client().ExtConn.List(ctx)
+	// Defensive nil checks to avoid panics when provider/client isn't
+	// initialized. Return a descriptive error so callers can surface it.
+	// Using a concrete *common.ProviderConfig (not an interface) makes cfg == nil
+	// a reliable check — there is no typed-nil ambiguity with a concrete pointer.
+	if cfg == nil {
+		return in, false, "", fmt.Errorf("list external connectors: provider config is nil")
+	}
+	cli := cfg.Client()
+	if cli == nil {
+		return in, false, "", fmt.Errorf("list external connectors: client not initialized")
+	}
+	if cli.ExtConn == nil {
+		return in, false, "", fmt.Errorf("list external connectors: extconn service unavailable")
+	}
+
+	connectors, err := cli.ExtConn.List(ctx)
 	if err != nil {
 		return in, false, "", fmt.Errorf("list external connectors: %w", err)
 	}

--- a/internal/provider/resource/node/extconn_normalize_test.go
+++ b/internal/provider/resource/node/extconn_normalize_test.go
@@ -1,0 +1,148 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rschmied/gocmlclient/pkg/models"
+
+	"github.com/ciscodevnet/terraform-provider-cml2/internal/cmlschema"
+	"github.com/ciscodevnet/terraform-provider-cml2/internal/common"
+)
+
+// newTestProviderConfig spins up a TLS httptest server using the provided mux
+// and returns an initialized *common.ProviderConfig that points at it.
+// The caller is responsible for calling srv.Close().
+func newTestProviderConfig(t *testing.T, mux *http.ServeMux) (*common.ProviderConfig, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewTLSServer(mux)
+
+	model := &cmlschema.ProviderModel{
+		Address:        types.StringValue(srv.URL),
+		Token:          types.StringValue("test-token"),
+		SkipVerify:     types.BoolValue(true),
+		NamedConfigs:   types.BoolValue(false),
+		UseCache:       types.BoolNull(),
+		TokenCache:     types.BoolValue(false),
+		TokenCacheFile: types.StringNull(),
+		CAcert:         types.StringNull(),
+		Username:       types.StringNull(),
+		Password:       types.StringNull(),
+		RequestHeaders: types.MapNull(types.StringType),
+		DynamicConfig:  types.BoolNull(),
+	}
+
+	var diags diag.Diagnostics
+	cfg := common.NewProviderConfig(model).Initialize(context.Background(), &diags)
+	if diags.HasError() {
+		srv.Close()
+		t.Fatalf("provider config initialization failed: %v", diags.Errors())
+	}
+	return cfg, srv
+}
+
+func extConnMux(t *testing.T, conns []*models.ExtConn, mode *int) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v0/system/external_connectors", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if *mode == 1 {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(conns)
+	})
+	return mux
+}
+
+func TestNormalizeExtConnConfig(t *testing.T) {
+	conns := []*models.ExtConn{
+		{ID: models.UUID("1"), DeviceName: "virbr0", Label: "NAT"},
+		{ID: models.UUID("2"), DeviceName: "bridge0", Label: "System Bridge"},
+	}
+
+	mode := 0
+	cfg, srv := newTestProviderConfig(t, extConnMux(t, conns, &mode))
+	defer srv.Close()
+
+	// device-name should be normalized to label and marked changed
+	norm, changed, warn, err := normalizeExtConnConfig(context.Background(), cfg, "virbr0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed || norm != "NAT" || warn == "" {
+		t.Fatalf("normalize mismatch: got=%q changed=%v warn=%q", norm, changed, warn)
+	}
+
+	// exact label should not be changed
+	norm2, changed2, _, err := normalizeExtConnConfig(context.Background(), cfg, "System Bridge")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed2 || norm2 != "System Bridge" {
+		t.Fatalf("expected no-change for label: got=%q changed=%v", norm2, changed2)
+	}
+
+	// empty / whitespace input is a no-op — List is never called
+	ne, nc, nw, err := normalizeExtConnConfig(context.Background(), cfg, "   ")
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if ne != "" || nc || nw != "" {
+		t.Fatalf("expected empty no-op for whitespace: got=%q changed=%v warn=%q", ne, nc, nw)
+	}
+
+	// unknown connector — no device-name or label match, returned as-is (no change)
+	nu, ncu, _, err := normalizeExtConnConfig(context.Background(), cfg, "unknown-conn")
+	if err != nil {
+		t.Fatalf("unexpected error for unknown input: %v", err)
+	}
+	if ncu || nu != "unknown-conn" {
+		t.Fatalf("expected no-change for unknown connector: got=%q changed=%v", nu, ncu)
+	}
+
+	// API error path: server returns 500 — error must propagate
+	mode = 1
+	if _, _, _, err := normalizeExtConnConfig(context.Background(), cfg, "virbr0"); err == nil {
+		t.Fatalf("expected error when API returns 500")
+	}
+}
+
+func TestNormalizeExtConnConfig_NilGuards(t *testing.T) {
+	ctx := context.Background()
+
+	// nil cfg — concrete pointer nil, check is reliable
+	_, _, _, err := normalizeExtConnConfig(ctx, nil, "virbr0")
+	if err == nil {
+		t.Fatal("expected error for nil cfg")
+	}
+
+	// uninitialised ProviderConfig — cfg.Client() returns nil
+	uninit := common.NewProviderConfig(&cmlschema.ProviderModel{
+		Address:        types.StringValue("https://localhost"),
+		Token:          types.StringValue("t"),
+		SkipVerify:     types.BoolValue(true),
+		NamedConfigs:   types.BoolValue(false),
+		UseCache:       types.BoolNull(),
+		TokenCache:     types.BoolValue(false),
+		TokenCacheFile: types.StringNull(),
+		CAcert:         types.StringNull(),
+		Username:       types.StringNull(),
+		Password:       types.StringNull(),
+		RequestHeaders: types.MapNull(types.StringType),
+		DynamicConfig:  types.BoolNull(),
+	})
+	_, _, _, err = normalizeExtConnConfig(ctx, uninit, "virbr0")
+	if err == nil {
+		t.Fatal("expected error for uninitialized cfg (nil client)")
+	}
+}


### PR DESCRIPTION
- switch extconn_normalize.go to concrete *ProviderConfig type; nil check is now reliable (no typed-nil ambiguity)
- add nil guards for cfg, cfg.Client(), and cli.ExtConn with descriptive errors
- add extconn_normalize_test.go: device-name→label, label no-op, empty input, unknown connector, API error, nil-guard cases
- add node_test case suppressing default config for unmanaged_switch nodes
- apply gofumpt formatting fixes (configure.go, groups.go, images.go, users.go, utilities.go, annotation_test.go, build.go, lab_test.go)